### PR TITLE
Include an indication to which image is referred to.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -77,7 +77,10 @@ class Parser
         $alts = [];
         if ($this->getDomElements('img')->length > 0) {
             foreach ($this->getDomElements('img') as $img) {
-                $alts[] = trim($img->getAttribute('alt'));
+                $alts[] = [
+                    trim($img->getAttribute('src')),
+                    trim($img->getAttribute('alt'))
+                ];
             }
         }
         return $alts;


### PR DESCRIPTION
Included the image source to help identify images with (or without) ALT tags.